### PR TITLE
fix booth numbering

### DIFF
--- a/commands.rb
+++ b/commands.rb
@@ -203,14 +203,14 @@ def process_results
 				parties.each do |party|
 					party_number = party['p_no']
 					p_votes = party.xpath("./votes").text
-					sql << "(#{vp['e_no']},#{vp['vp_no']},#{party_number},1,#{p_votes}),"
+					sql << "(#{vp['e_no']},#{a.text[5..7]},#{party_number},1,#{p_votes}),"
 				end
 
 				candidates = bth.xpath("//candidate")
 				candidates.each do |candidate|
 					candidate_number = candidate["c_no"]
 					c_votes = candidate.xpath("./votes").text
-					sql << "(#{vp['e_no']},#{vp['vp_no']},#{candidate_number},2,#{c_votes}),"
+					sql << "(#{vp['e_no']},#{a.text[5..7]},#{candidate_number},2,#{c_votes}),"
 				end
 			end
 		end

--- a/results.rb
+++ b/results.rb
@@ -27,14 +27,14 @@ results = "electorate_number|booth_number|ttype|number|votes\n"
 			parties.each do |party|
 				party_number = party['p_no']
 				p_votes = party.xpath("./votes").text
-				results << "#{vp['e_no']}|#{vp['vp_no']}|'p'|#{party_number}|#{p_votes}\n"
+				results << "#{vp['e_no']}|#{a.text[5..7]}|'p'|#{party_number}|#{p_votes}\n"
 			end
 
 			candidates = bth.xpath("//candidate")
 			candidates.each do |candidate|
 				candidate_number = candidate["c_no"]
 				c_votes = candidate.xpath("./votes").text
-				results << "#{vp['e_no']}|#{vp['vp_no']}|'c'|#{candidate_number}|#{c_votes}\n"
+				results << "#{vp['e_no']}|#{a.text[5..7]}|'c'|#{candidate_number}|#{c_votes}\n"
 			end
 		end
 	end


### PR DESCRIPTION

Stupid XML doesn't have the right booth numbering info in it.  We can work around by stripping the value we need from the name of the XML file.